### PR TITLE
adding global reference in order to perform node insertions

### DIFF
--- a/lib/ztree-for-react.js
+++ b/lib/ztree-for-react.js
@@ -1,5 +1,7 @@
 'use strict';
 
+global.ztree = {}
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
@@ -54,6 +56,9 @@ var ReactZtree = function (_Component) {
     key: 'renderZtreeDom',
     value: function renderZtreeDom() {
       var ztreeObj = this.ztreeObj = _jquery2.default.fn.zTree.init(this.getTreeDom(), this.getTreeSetting(), this.props.nodes);
+      if ('instanceId' in this.props) {
+        global.ztree[this.props.instanceId] = ztreeObj
+      }
       return ztreeObj;
     }
   }, {


### PR DESCRIPTION
First of all, thanks for building this. 

Having worked with your wrapper for a bit, I forked and made these changes to allow a global reference to reference the internal zTree. This allows an external call to access the zTree methods and perform post mount tree manipulations.

This doesn't seem to be the best approach but I wanted to offer it in case anyone else might have any better ideas for allowing zTree node manipulation.

Thanks!